### PR TITLE
replaced stakingkeeper with consumerkeeper in slashingkeeper creation

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -469,7 +469,11 @@ func NewIntoApp(
 	)
 
 	app.SlashingKeeper = slashingkeeper.NewKeeper(
-		appCodec, legacyAmino, runtime.NewKVStoreService(keys[slashingtypes.StoreKey]), app.StakingKeeper, authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		appCodec,
+		legacyAmino,
+		runtime.NewKVStoreService(keys[slashingtypes.StoreKey]),
+		&app.ConsumerKeeper,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 	)
 
 	invCheckPeriod := cast.ToUint(appOpts.Get(server.FlagInvCheckPeriod))


### PR DESCRIPTION
Fixed incorrect SlashingKeeper wiring, chain panicked during finalization of second block.

ConsumerKeeper has now replaced the StakingKeeper in the SlashingKeeper creation.